### PR TITLE
Fix build with C23

### DIFF
--- a/util.h
+++ b/util.h
@@ -72,12 +72,14 @@ typedef unsigned int tbyte_t;
 typedef unsigned long int tbyte_t;
 #  endif
 
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
 /** Truth value */
 typedef enum
 {
   false = 0,	/**< false, binary digit '0' */
   true		/**< true, binary digit '1' */
 } bool;
+#endif
 
 /** Commodore file types */
 enum Filetype


### PR DESCRIPTION
In C23, `true` and `false` are keywords and can't be used as names in declarations.  But that also means there is no need to declare them.